### PR TITLE
feat: add time limit to wait for results

### DIFF
--- a/exb_sdk/workflow_client/exceptions.py
+++ b/exb_sdk/workflow_client/exceptions.py
@@ -4,8 +4,15 @@ from httpx import Response
 class DocumentProcessingError(Exception):
     """Raised when an error occurs during an extraction."""
 
+    def __init__(self, message: str = "Error processing document") -> None:  # noqa: D107
+        super().__init__(message)
+
+
+class DocumentProcessingTimeoutError(Exception):
+    """Raised when an error occurs during an extraction."""
+
     def __init__(self) -> None:  # noqa: D107
-        message = "Error processing document"
+        message = "Error processing document due to timeout"
         super().__init__(message)
 
 


### PR DESCRIPTION
To prevent a wait-forever situation I've added a timeout check for the get-result request loop.

Can be set as seconds to wait and defaults to 30 minutes.